### PR TITLE
fix: correct button background color

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -7,7 +7,7 @@ const buttonVariants = cva(
     {
         variants: {
             variant: {
-                default: "bg-black-600 text-white hover:bg-blue-700",
+                default: "bg-blue-600 text-white hover:bg-blue-700",
                 outline: "border border-gray-300 text-gray-700 bg-white hover:bg-gray-50",
                 ghost: "bg-transparent hover:bg-gray-100",
             },


### PR DESCRIPTION
## Summary
- fix button background color for default variant

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_683f7197c1088323b7bb625e104fed9a