### PR TITLE
docs: fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,6 @@ npm install
 
 # Lancer l'application
 npm run dev
+```
+
+L'application est maintenant prête.


### PR DESCRIPTION
## Summary
- fix the Markdown code block in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840133df5748323bac6c6b40d2a331f