### PR TITLE
Add vitest setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,12 @@ npm install
 
 # Lancer l'application
 npm run dev
+```
+
+## 🧪 Tests
+
+Les tests unitaires sont écrits avec [Vitest](https://vitest.dev/).
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.11",
@@ -72,6 +73,8 @@
     "tailwindcss": "^3.4.11",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.5.0",
+    "@types/node": "^22.0.0"
   }
 }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from './utils'
+
+describe('cn', () => {
+  it('merges class names', () => {
+    expect(cn('foo', 'bar', 'foo')).toBe('foo bar')
+  })
+})


### PR DESCRIPTION
## Summary
- add vitest test command and dependencies
- verify `cn` helper in a unit test
- document how to run tests in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840133e275083238df9c774cb9c7a15