### PR TITLE
Fix class name merge util

### DIFF
--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -2,5 +2,12 @@ import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {
-    return twMerge(clsx(inputs))
+  const merged = twMerge(clsx(...inputs))
+  const unique: string[] = []
+  for (const cls of merged.split(/\s+/)) {
+    if (cls && !unique.includes(cls)) {
+      unique.push(cls)
+    }
+  }
+  return unique.join(" ")
 }


### PR DESCRIPTION
## Summary
- handle deduplication in the `cn` utility

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684017d4f2288323bd14a3547c0447f4