### PR TITLE
Fix API paths and button color

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -7,7 +7,7 @@ const buttonVariants = cva(
     {
         variants: {
             variant: {
-                default: "bg-black-600 text-white hover:bg-blue-700",
+                default: "bg-blue-600 text-white hover:bg-blue-700",
                 outline: "border border-gray-300 text-gray-700 bg-white hover:bg-gray-50",
                 ghost: "bg-transparent hover:bg-gray-100",
             },

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -35,7 +35,7 @@ export async function addContactAPI(contact: Omit<Contact, "id">): Promise<void>
 }
 
 export async function deleteContactAPI(id: string): Promise<void> {
-  await api.delete(`${id}`);
+  await api.delete(`/${id}`);
 }
 
 export async function updateContactAPI(id: string, contact: Omit<Contact, "id">): Promise<void> {
@@ -47,5 +47,5 @@ export async function updateContactAPI(id: string, contact: Omit<Contact, "id">)
     societeContact: contact.company,
     photoContact: contact.avatar,
   };
-  await api.put(`${id}`, payload);
+  await api.put(`/${id}`, payload);
 }


### PR DESCRIPTION
## Summary
- fix API endpoints to include leading slash
- correct default button color

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Missing modules such as '@tanstack/react-query')*

------
https://chatgpt.com/codex/tasks/task_e_683f70de21d88323a755db56eb714233